### PR TITLE
Update radixconfig.yaml

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -23,10 +23,10 @@ spec:
           replicas: 2
           resources:
             requests:
-              memory: "10Mi"
+              memory: "30Mi"
               cpu: "5m"
             limits:
-              memory: "20Mi"
+              memory: "30Mi"
               cpu: "10m"
         - environment: qa
           runAsNonRoot: true


### PR DESCRIPTION
- prod environment failes in dev cluster with OOMKilled. Increase memory request and limit to 30Mi.