### PR TITLE
increase cpu limit to speed up startup time

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -27,7 +27,7 @@ spec:
               cpu: "10m"
             limits:
               memory: "150Mi"
-              cpu: "10m"
+              cpu: "1000m" # docusaurus use a lot of cpu during startup/init
           volumeMounts:
             - name: tmp
               path: /tmp
@@ -53,7 +53,7 @@ spec:
               cpu: "10m"
             limits:
               memory: "150Mi"
-              cpu: "10m"
+              cpu: "1000m" # docusaurus use a lot of cpu during startup/init
           volumeMounts:
             - name: tmp
               path: /tmp


### PR DESCRIPTION
## What type of PR? (can choose many)
- [ ] 🍕 Added/Updated documentation
- [ ] 🎨 Style
- [ ] 🔒 Security
- [x] Configuration

## Description
Docusaurus requires a lot of CPU durinit startup. With too low cpu limit, it can take many minutes for the readiness probe to succeed

