### PR TITLE
fix: update hardware info for gpu-nvidia-1-v1 node type

### DIFF
--- a/public-site/docs/radix-config/index.md
+++ b/public-site/docs/radix-config/index.md
@@ -1529,9 +1529,9 @@ The `nodeType` property in `runtime` defines the particular Kubernetes cluster n
   * Memory: 1946 GB
   * GPU: n/a
 * `gpu-nvidia-1-v1` 
-  * CPU: AMD EPYC 7V13 (Milan) [x86-64], 24 cores
-  * Memory: 220 GB
-  * GPU: 1 x Nvidia PCIe A100 GPU, 80 GB of memory 
+  * CPU: AMD EPYC (Genoa) [x86-64], 40 cores
+  * Memory: 320 GB
+  * GPU: 1 x Nvidia PCIe H100 GPU, 94 GB of memory 
 :::warning
 Nodes, available with `nodeType` property are usually much more expensive than default nodes. Please use them only when needed, preferable with jobs, as these nodes automatically scaled up on started component or jobs (which can take up to 5 minutes) and scaled down (within minutes) when the job is finished.
 :::


### PR DESCRIPTION
## What type of PR? (can choose many)
- [x] 🍕 Added/Updated documentation
- [ ] 🎨 Style
- [ ] 🔒 Security

## Description
We changed the underlying VM type for nodeType `gpu-nvidia-1-v1` in radixconfig from `Standard_NC24ads_A100_v4` to `Standard_NC40ads_H100_v5`.
This PR updated the hardware for the new VM type

