### PR TITLE
Add OAuth header migration guide to documentation.

### DIFF
--- a/docs/guides/oauth-header-migration-guide/index.md
+++ b/docs/guides/oauth-header-migration-guide/index.md
@@ -1,0 +1,54 @@
+---
+title: OAuth 2.0 Header Migration Guide
+---
+
+# What's changing?
+We're updating our platform's authentication setup.
+The only visible change is a switch in which headers carry user identity information.
+Today, your application receives both _X-Auth-Request-*_ and _X-Forwarded-*_ identity headers like:
+- _X-Auth-Request-User_
+- _X-Forwarded-User_
+
+After migrating to the new setup, only _X-Forwarded-*_ headers will remain.
+
+:::info
+For now you can choose to opt-in to this change, but this migration will be enforced for all applications in the near future.
+:::
+
+# Why this change is happening
+Ingress-nginx, our current ingress controller, will be retired in March 2026. To prepare for this, we're upgrading our infrastructure to use a new ingress controller called Istio, which will improve performance and reliability.
+
+This upgrade requires us to update how OAuth2Proxy operates. Currently, it relies on nginx-specific directives that are not compatible with Istio. To make it compatible with our new infrastructure, we're moving the OAuth2Proxy from sidecar mode to proxy mode. As a side effect of this architectural change, the headers carrying user information will change from _X-Auth-Request-*_ to _X-Forwarded-*_ headers.
+
+# What do you need to do?
+If your application reads user information from request headers, update it to use _X-Forwarded-*_ instead of _X-Auth-Request-*_.
+Currently both header types are available.
+This is the only required code change.
+
+# How to enable the new header format (opt-in)
+Currently both header formats exist (with the same values), so you can safely test before opting in.
+You choose when to switch by adding the `radix.equinor.com/preview-oauth2-proxy-mode` annotation to your _radixconfig.yaml_ file.
+The value for this annotation is a comma-separated list of environments where you want to enable proxy mode. You can also set a wildcard (`*`) to cover all environments.
+
+```yaml
+apiVersion: radix.equinor.com/v1
+kind: RadixApplication
+metadata:
+  name: my-app
+  annotations:
+   radix.equinor.com/preview-oauth2-proxy-mode: "dev,qa"
+```
+
+After adding the annotation you need to deploy your application again.
+
+# What to expect during the switch
+There may be a couple of seconds of downtime during the switch.
+After the switch, Only _X-Forwarded-*_ headers remain.
+No changes to login flow, authentication prompts, or tokens.
+
+# Summary
+You need to:
+
+- Update your app to read _X-Forwarded-*_ headers
+- Add the opt‑in annotation when ready
+- Redeploy your application

--- a/docs/guides/oauth-header-migration-guide/index.md
+++ b/docs/guides/oauth-header-migration-guide/index.md
@@ -40,7 +40,7 @@ metadata:
    radix.equinor.com/preview-oauth2-proxy-mode: "dev,qa"
 ```
 
-After adding the annotation you need to deploy your application to the affected again.
+After adding the annotation you need to deploy your application to the affected environments again.
 
 # What to expect during the switch
 There may be a couple of seconds of downtime during the switch.

--- a/docs/guides/oauth-header-migration-guide/index.md
+++ b/docs/guides/oauth-header-migration-guide/index.md
@@ -40,7 +40,7 @@ metadata:
    radix.equinor.com/preview-oauth2-proxy-mode: "dev,qa"
 ```
 
-After adding the annotation you need to deploy your application again.
+After adding the annotation you need to deploy your application to the affected again.
 
 # What to expect during the switch
 There may be a couple of seconds of downtime during the switch.

--- a/docs/guides/oauth-header-migration-guide/index.md
+++ b/docs/guides/oauth-header-migration-guide/index.md
@@ -5,14 +5,14 @@ title: OAuth 2.0 Header Migration Guide
 # What's changing?
 We're updating our platform's authentication setup.
 The only visible change is a switch in which headers carry user identity information.
-Today, your application receives both _X-Auth-Request-*_ and _X-Forwarded-*_ identity headers like:
+Today, if you have set the [`setXAuthRequestHeaders`](../../radix-config/index.md#oauth2) property to _true_ in _radixconfig.yaml_, your application receives both _X-Auth-Request-*_ and _X-Forwarded-*_ identity headers like:
 - _X-Auth-Request-User_
 - _X-Forwarded-User_
 
 After migrating to the new setup, only _X-Forwarded-*_ headers will remain.
 
 :::info
-For now you can choose to opt-in to this change, but this migration will be enforced for all applications in the near future.
+For now you can choose to opt-in to this change, but this migration will be enforced for all applications **in two weeks** on February 16th.
 :::
 
 # Why this change is happening
@@ -21,7 +21,8 @@ Ingress-nginx, our current ingress controller, will be retired in March 2026. To
 This upgrade requires us to update how OAuth2Proxy operates. Currently, it relies on nginx-specific directives that are not compatible with Istio. To make it compatible with our new infrastructure, we're moving the OAuth2Proxy from sidecar mode to proxy mode. As a side effect of this architectural change, the headers carrying user information will change from _X-Auth-Request-*_ to _X-Forwarded-*_ headers.
 
 # What do you need to do?
-If your application reads user information from request headers, update it to use _X-Forwarded-*_ instead of _X-Auth-Request-*_.
+If you have not set the [`setXAuthRequestHeaders`](../../radix-config/index.md#oauth2) property (or set it to _false_), you do not have to do anything.
+If you have set it to _true_ and your application reads user information from request headers, update it to use _X-Forwarded-*_ instead of _X-Auth-Request-*_.
 Currently both header types are available.
 This is the only required code change.
 

--- a/docs/radix-config/index.md
+++ b/docs/radix-config/index.md
@@ -1384,7 +1384,13 @@ oauth2:
 - `clientId` Required - The client ID of the application, e.g. the application ID of an application registration in Azure AD.
 
 - `scope` Optional. Default **openid profile email** - List of OIDC scopes and identity platform specific scopes. More information about scopes when using the Microsoft Identity Platform can be found [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent).
-- `setXAuthRequestHeaders` Optional. Default **false** - Adds claims from the access token to the _X-Auth-Request-User_, _X-Auth-Request-Groups_, _X-Auth-Request-Email_ and _X-Auth-Request-Preferred-Username_ request headers. The Access Token is added to the _X-Auth-Request-Access-Token_ header.
+- `setXAuthRequestHeaders` Optional. Default **false** - Adds claims from the access token to the _X-Forwarded-User_, _X-Forwarded-Groups_, _X-Forwarded-Email_ and _X-Forwarded-Preferred-Username_ request headers. The Access Token is added to the _X-Forwarded-Access-Token_ header.
+
+:::important
+_X-Auth-Request-*_ headers have been deprecated in favor of _X-Forwarded-*_ headers.
+A guide on how to migrate can be found [here](../guides/oauth-header-migration-guide/index.md)
+:::
+
 - `setAuthorizationHeader` Optional. Default **false** - Adds the OIDC ID Token in the _Authorization: Bearer_ request header.
 - `proxyPrefix` Optional. Default **/oauth2** - The root path that the OAuth2 proxy should be nested under. The OAuth2 proxy exposes various [endpoints](https://oauth2-proxy.github.io/oauth2-proxy/docs/features/endpoints) from this root path.
 - `oidc` OIDC configuration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,8 @@ nav:
       - Build Secrets: guides/build-secrets/index.md
       - Environment Variables: guides/environment-variables/index.md
       - Authentication:
-          - OAuth 2.0 Authentication: guides/authentication/index.md
+          - OAuth 2.0 Authenticationtest: guides/authentication/index.md
+          - OAuth 2.0 Header Migration Guide: guides/oauth-header-migration-guide/index.md
           - Azure Workload Identity: guides/workload-identity/index.md
       - Azure Key Vault: guides/azure-key-vaults/index.md
       - External DNS Alias:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ nav:
       - Build Secrets: guides/build-secrets/index.md
       - Environment Variables: guides/environment-variables/index.md
       - Authentication:
-          - OAuth 2.0 Authenticationtest: guides/authentication/index.md
+          - OAuth 2.0 Authentication: guides/authentication/index.md
           - OAuth 2.0 Header Migration Guide: guides/oauth-header-migration-guide/index.md
           - Azure Workload Identity: guides/workload-identity/index.md
       - Azure Key Vault: guides/azure-key-vaults/index.md

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -60,6 +60,7 @@ const sidebars: SidebarsConfig = {
         label: 'Authentication',
         items: [
           'guides/authentication/index',
+          'guides/oauth-header-migration-guide/index',
           'guides/workload-identity/index',
         ]
       },


### PR DESCRIPTION
<!-- 
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes
  - 📝 Use descriptive commit messages
  - 📗 Update applicable documentation
-->

## What type of PR? (can choose many)
- [X] 🍕 Added/Updated documentation
- [ ] 🎨 Style
- [ ] 🔒 Security

## Description
We are putting OAuth2Proxy into proxy mode. Identity headers passed on to the client will change, and we need to add a migration guide for the users to follow.

