### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build-and-publish-varia-techdocs.yaml
+++ b/.github/workflows/build-and-publish-varia-techdocs.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-and-publish-varia-techdocs.yaml
+++ b/.github/workflows/build-and-publish-varia-techdocs.yaml
@@ -8,6 +8,7 @@ on:
       - varia-makefile
   workflow_dispatch:
 
+permissions: {}
 jobs:
   techdocs:
     runs-on: ubuntu-latest
@@ -17,22 +18,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "20"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # @v6.8.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Install techdocs-cli
         run: npm install -g @techdocs/cli
@@ -41,7 +42,7 @@ jobs:
         run: uv run techdocs-cli generate --no-docker
 
       - name: "Az login"
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: 1fee4604-0e5f-4b2a-9481-e466bbec1cea
           tenant-id: 3aa4a235-b6e2-48d5-9195-7fcf05b459b0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build docker image
         env:
           REF: ${{ github.sha }}
@@ -23,8 +23,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: equinor/radix-github-actions@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: equinor/radix-github-actions@b23674a56b82a1da783b507bc7f15e7ca7067dd8 # v2.0.2
       - name: "Validate public-site"
         run: rx validate radix-config --config-file radixconfig.yaml
       - name: "Validate oauth example radix-app"
@@ -40,15 +40,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # @v6.8.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Run plugin tests
         run:  uv run python ./scripts/test_plugin.py

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build docker image
         env:
           REF: ${{ github.sha }}
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: equinor/radix-github-actions@v2
       - name: "Validate public-site"
         run: rx validate radix-config --config-file radixconfig.yaml
@@ -40,7 +40,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/docs/guides/deploy-only/example-github-action-to-create-radix-deploy-pipeline-job.md
+++ b/docs/guides/deploy-only/example-github-action-to-create-radix-deploy-pipeline-job.md
@@ -77,19 +77,19 @@ jobs:
           echo "repo=${repo}" >> $GITHUB_OUTPUT 
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       # Login, build and push the image to your preffered registry
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }} # Use the default GITHUB_TOKEN for ghcr.io
           
       - name: Build and push docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           push: true
             ghcr.io/${{ steps.metadata.outputs.repo }}:latest

--- a/docs/guides/deploy-only/example-github-action-to-create-radix-deploy-pipeline-job.md
+++ b/docs/guides/deploy-only/example-github-action-to-create-radix-deploy-pipeline-job.md
@@ -63,7 +63,7 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
             
       - name: Build image tags
         id: metadata

--- a/docs/guides/deploy-only/index.md
+++ b/docs/guides/deploy-only/index.md
@@ -252,7 +252,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set RELEASE_VERSION
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 

--- a/docs/guides/deploy-only/migrating-radix-github-action-v1-to-v2.md
+++ b/docs/guides/deploy-only/migrating-radix-github-action-v1-to-v2.md
@@ -24,7 +24,7 @@ jobs:
       - name: 'Get Azure principal token for Radix'
         run: |
           echo "APP_SERVICE_ACCOUNT_TOKEN=hello-world" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Validate public-site'
         uses: equinor/radix-github-actions@v1
         with:
@@ -46,7 +46,7 @@ jobs:
   validate-radixconfig:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: equinor/radix-github-actions@v2
       - name: 'Validate public-site'
         run: rx validate radix-config --config-file radixconfig.yaml
@@ -109,7 +109,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: equinor/radix-github-actions@v2
       with:
         azure_client_id: "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
Update deprecated GitHub Actions to versions compatible with Node.js 24.\n\n- Update actions/checkout to v6\n- Update radix-reusable-workflows to v1.1.0\n\nNode.js 20 actions are deprecated and will be forced to run with Node.js 24 by default starting June 2nd, 2026.