### PR TITLE
feat: Deprecate acr run tasks

### DIFF
--- a/docs/guides/build-secrets/index.md
+++ b/docs/guides/build-secrets/index.md
@@ -3,11 +3,20 @@ title: Build Secrets
 ---
 
 # Build secrets
-* [With an option `useBuildKit: false`](./#build-secrets-without-buildkit)
-* [With an option `useBuildKit: true`](./#build-secrets-with-buildkit)
 
+:::warning Deprecated: Build secrets without BuildKit
+The legacy build secret method (`useBuildKit: false` or not set) is **deprecated**. If you are using build secrets with the legacy method, you should migrate to `useBuildKit: true` as soon as possible. `useBuildKit: true` is more secure, enables further security improvements not possible with the legacy method, and is faster in many cases. See [Build secrets with BuildKit](./#build-secrets-with-buildkit) for the recommended approach.
+:::
 
-## Build secrets without BuildKit  
+* [With `useBuildKit: true` **(recommended)**](./#build-secrets-with-buildkit)
+* [With `useBuildKit: false` **(deprecated)**](./#build-secrets-without-buildkit)
+
+## Build secrets without BuildKit (deprecated) {#build-secrets-without-buildkit}
+
+:::danger Deprecated
+This method is deprecated and will be removed in a future release. Migrate to [`useBuildKit: true`](../../radix-config/index.md#usebuildkit).
+:::
+
 With an option `spec.build.useBuildKit: false`, to ensure that multiline build secrets are handled correct by the build, **all** [Build secrets](../../radix-config/index.md#secrets) are passed as `ARG`-s during container build, base-64 encoded (they need to be decoded before use).
 
 ```dockerfile
@@ -45,8 +54,8 @@ FROM mcr.microsoft.com/dotnet/aspnet:5.0
 ARG SECRET1
 #.....
 ```
-## Build secrets with BuildKit  
-With an option `spec.build.useBuildKit: true`, build secrets are not available as `ARG`-s during container build. [Build secrets](../../radix-config/index.md#secrets) can be mounted as files within the `RUN` directive. BuildKit is an improved backend to replace the legacy builder. Read [more](https://docs.docker.com/build/buildkit/).
+## Build secrets with BuildKit (recommended) {#build-secrets-with-buildkit}
+With `spec.build.useBuildKit: true`, build secrets are not available as `ARG`-s during container build. [Build secrets](../../radix-config/index.md#secrets) can be mounted as files within the `RUN` directive. BuildKit is an improved backend to replace the legacy builder. Read [more](https://docs.docker.com/build/buildkit/).
 
 :::tip
 Docker build workflow has some differences for the command `docker build`, for example how [ARG](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact) with BuildKit [persists across build stages](https://github.com/moby/buildkit/issues/1977).

--- a/docs/radix-config/index.md
+++ b/docs/radix-config/index.md
@@ -59,14 +59,14 @@ spec:
 The `build` section of the spec contains configuration used during the build process of the components and jobs.
 
 ### `useBuildKit`
-`useBuildKit` - (optional, default `false` for backwards compatibility) builds components and jobs using [Buildah](https://www.redhat.com/en/topics/containers/what-is-buildah). This option provides several benefits over the default Radix build engine:
-- Secure handling of [**build secrets**](../guides/build-secrets/index.md#build-secrets-with-buildkit).
+`useBuildKit` - builds components and jobs using [Buildah](https://www.redhat.com/en/topics/containers/what-is-buildah). **This should always be set to `true`.** Benefits over the legacy build engine include:
+- **More secure** handling of [**build secrets**](../guides/build-secrets/index.md#build-secrets-with-buildkit), and enables further security improvements not possible with the legacy method.
 - Caching support that can reduce build time, see [`useBuildCache`](#usebuildcache).
 - Use images from protected container registries defined in [`privateImageHubs`](#privateimagehubs), in the Dockerfile's `FROM` instructions.
-- Faster builds due to less steps involved and higher performance nodes.
+- **Faster builds** due to fewer steps involved and higher performance nodes.
 
-:::tip
-`useBuildKit` is the recommended way to build containers and will be the default in the future.
+:::warning Deprecated: `useBuildKit: false` (or not set)
+Not setting `useBuildKit` to `true` is **deprecated** and will be removed in a future release. This primarily affects users who use [**build secrets**](../guides/build-secrets/index.md) — if you rely on build secrets with the legacy method (`useBuildKit: false` or unset), you should migrate to `useBuildKit: true` as soon as possible. See the [build secrets guide](../guides/build-secrets/index.md#build-secrets-with-buildkit) for migration instructions.
 :::
 
 ### `useBuildCache`
@@ -97,8 +97,8 @@ spec:
 `secrets` - (optional) Defines secrets to be used in Dockerfiles or [sub-pipelines](../guides/sub-pipeline/index.md). Secrets values must be set in Radix Web Console. `build-deploy` jobs will fail if not all secret values are set.
 
 :::tip
-* When an option `useBuildKit: false`, to ensure that multiline build secrets are handled correct by the build, **all** build secrets are passed as `ARG`-s during container build, base-64 encoded (they need to be decoded before use).
-* When an option `useBuildKit: true`, build secrets are not available as `ARG`-s during container build, but they can be mounted as files. Secret values are not base-64 encoded in these files.
+* When `useBuildKit: true`, build secrets are not available as `ARG`-s during container build, but they can be mounted as files. Secret values are not base-64 encoded in these files.
+* **(Deprecated)** When `useBuildKit: false` or not set, build secrets are passed as `ARG`-s during container build, base-64 encoded. This method is deprecated — migrate to `useBuildKit: true`.
 
 Read the [build secrets](../guides/build-secrets/index.md) guide to see how to use build secrets in a Dockerfile.
 :::


### PR DESCRIPTION
Make it clear that setting `useBuildKit: false` (or not setting it) is deprecated

<img width="1007" height="452" alt="Screenshot 2026-04-09 at 15 37 27" src="https://github.com/user-attachments/assets/6d9f1d96-f617-4993-b9ba-ef834a73b4fc" />
<img width="1000" height="387" alt="Screenshot 2026-04-09 at 15 39 38" src="https://github.com/user-attachments/assets/69e753fe-7e54-4bf4-b87c-7ee801671ec9" />
<img width="1019" height="291" alt="Screenshot 2026-04-09 at 15 39 52" src="https://github.com/user-attachments/assets/d478c51c-c296-4469-b4c9-03b661d7dc8e" />

